### PR TITLE
Move away from deprecated use of #pipelined

### DIFF
--- a/lib/redrate/ring.rb
+++ b/lib/redrate/ring.rb
@@ -26,9 +26,9 @@ module Redrate
     def rotate!
       current_head = head
       current_time = now
-      @redis.pipelined do
-        @redis.lset(ring_key, current_head, current_time.to_s)
-        @redis.set(head_key, (current_head + 1) % @size)
+      @redis.pipelined do |pipeline|
+        pipeline.lset(ring_key, current_head, current_time.to_s)
+        pipeline.set(head_key, (current_head + 1) % @size)
       end
     end
 
@@ -70,11 +70,11 @@ module Redrate
       def initialize_ring
         return unless @redis.llen(ring_key).zero?
 
-        @redis.pipelined do
+        @redis.pipelined do |pipeline|
           1.upto(@size) do
-            @redis.lpush(ring_key, @default)
+            pipeline.lpush(ring_key, @default)
           end
-          @redis.set(head_key, 0)
+          pipeline.set(head_key, 0)
         end
       end
 


### PR DESCRIPTION
This adds support for the latest version of redis-rb, and _should_ work for redis-rb versions down to 3.0 (might want to confirm this).

Deprecation message:
```
Pipelining commands on a Redis instance is deprecated and will be removed in Redis 5.0.0.

redis.pipelined do
  redis.get("key")
end

should be replaced by

redis.pipelined do |pipeline|
  pipeline.get("key")
end
```